### PR TITLE
Add python3-pyelftools dependency to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ git clone <url-to-your-fork.git>
 Install the necessary build dependencies with
 ```bash
 sudo apt-get update
-sudo apt-get install git build-essential binutils-mips-linux-gnu python3
+sudo apt-get install git build-essential binutils-mips-linux-gnu python3 python3-pyelftools
 ```
 
 Add your legally-obtained Master Quest PAL GCN Debug ROM into the root folder, and name it `baserom_original.z64`.


### PR DESCRIPTION
I had to install this additional dependency before I was able to build the ROM successfully, otherwise the build fails with:

```
Traceback (most recent call last):
  File "/home/farmerbb/sw97/tools/z64compress_wrapper.py", line 9, in <module>
    from elftools.elf.elffile import ELFFile
ModuleNotFoundError: No module named 'elftools'
make: *** [Makefile:222: sw97.z64] Error 1
```